### PR TITLE
override hashcode method for Menu.class

### DIFF
--- a/blade-service-api/blade-system-api/src/main/java/org/springblade/system/entity/Menu.java
+++ b/blade-service-api/blade-system-api/src/main/java/org/springblade/system/entity/Menu.java
@@ -139,6 +139,4 @@ public class Menu implements Serializable {
 		return false;
 	}
 
-
-
 }

--- a/blade-service-api/blade-system-api/src/main/java/org/springblade/system/entity/Menu.java
+++ b/blade-service-api/blade-system-api/src/main/java/org/springblade/system/entity/Menu.java
@@ -120,6 +120,11 @@ public class Menu implements Serializable {
 
 
 	@Override
+	public int hashCode() {
+		return (this.getId() == null) ? -1 : this.getId();
+	}
+
+	@Override
 	public boolean equals(Object obj) {
 		if (this == obj) {
 			return true;
@@ -133,5 +138,7 @@ public class Menu implements Serializable {
 		}
 		return false;
 	}
+
+
 
 }


### PR DESCRIPTION
在`override` `equals(Object obj) `方法的同时，`override` `hashCode()` 方法